### PR TITLE
feat: 自動化管線迴圈與一鍵流程文件

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ agentic_rag/
 | `make search QUERY="關鍵問題"` | 進行語義搜尋 |
 | `make migrate-supabase` | 將 PostgreSQL 資料遷移至 Supabase |
 
+## 🔁 一鍵全自動流程
+若想從發現到向量化一次完成，可執行下列指令：
+
+```bash
+python -m scripts.auto_pipeline --domain https://example.com --batch_size 100
+```
+
+如需長時間執行，可加上 `--schedule 3600` 以每小時重新流程。
+
 ## 🪵 日誌
 執行上述指令或單獨呼叫腳本時，系統會在 `logs/` 目錄生成 `<腳本名稱>.log` 等日誌檔。
 例如可透過以下指令即時查看執行狀況：

--- a/scripts/auto_pipeline.py
+++ b/scripts/auto_pipeline.py
@@ -1,8 +1,9 @@
 """
 自動化爬蟲流程
 
-依序執行 discover -> crawl -> embed，可單次或週期性運行。
+循環執行 discover → crawl → embed，直到 URLScheduler 無待抓取 URL。
 """
+
 import argparse
 import asyncio
 import os
@@ -18,7 +19,12 @@ from spider.crawlers.robots_handler import (
     get_crawl_delay,
     is_allowed,
 )
+from spider.crawlers.url_scheduler import URLScheduler
+from spider.crawlers.progressive_crawler import ProgressiveCrawler
 from spider.utils.connection_manager import EnhancedConnectionManager
+from spider.utils.database_manager import EnhancedDatabaseManager
+from spider.utils.rate_limiter import AdaptiveRateLimiter
+from spider.utils.retry_manager import RetryManager
 from spider.utils.enhanced_logger import spider_logger
 
 # 建立日誌器
@@ -34,30 +40,62 @@ def import_script(name: str):
 
 
 
-async def run_once(domain: str, batch_size: int):
-    """執行一次完整流程"""
-    logger.info("開始執行一次管線流程")
+async def crawl_once(domain: str, batch_size: int) -> int:
+    """抓取一批 URL 並回傳處理數量"""
+    async with EnhancedDatabaseManager() as db_manager:
+        scheduler = URLScheduler(db_manager)
+        async with EnhancedConnectionManager(rate_limiter=AdaptiveRateLimiter()) as cm:
+            await fetch_and_parse(domain, cm)
+            crawl_delay = await get_crawl_delay(domain, cm)
+            if crawl_delay and crawl_delay > MAX_CRAWL_DELAY:
+                logger.warning(f"crawl-delay {crawl_delay}s 過大，終止爬取階段")
+                return 0
+            if crawl_delay:
+                rl = getattr(cm, "_rate_limiter", None)
+                if rl:
+                    rl.config.min_delay = max(rl.config.min_delay, float(crawl_delay))
+            crawler = ProgressiveCrawler(
+                scheduler,
+                RetryManager(),
+                cm,
+                batch_size=batch_size,
+                concurrency=batch_size,
+            )
+            processed = await crawler.crawl_batch()
+            logger.info(f"本輪抓取 {processed} 個 URL")
+            return processed
 
-    # discover 與 crawl 併發執行
-    discover = import_script("1_discover_urls")
-    crawl = import_script("2_crawl_content")
-    await asyncio.gather(
-        discover.main([domain]),
-        crawl.main(domain, batch_size),
-    )
 
-    # embed
-    embed = import_script("3_process_and_embed")
-    embed.main(batch_size)
+async def run_pipeline(domain: str, batch_size: int) -> None:
+    """持續執行 discover → crawl → embed，直到無待抓取 URL"""
+    current_batch = batch_size
+    round_count = 1
+    while True:
+        logger.info(f"開始第 {round_count} 輪流程，batch_size={current_batch}")
+        discover = import_script("1_discover_urls")
+        embed = import_script("3_process_and_embed")
 
-    logger.info("本輪流程完成")
-    spider_logger.log_statistics()
+        async with asyncio.TaskGroup() as tg:
+            tg.create_task(discover.main([domain]))
+            crawl_task = tg.create_task(crawl_once(domain, current_batch))
+
+        processed = crawl_task.result()
+        if processed == 0:
+            logger.info("URLScheduler 無待抓取 URL，流程結束")
+            break
+
+        embed.main(processed)
+        logger.info(f"完成向量化 {processed} 篇文章")
+        spider_logger.log_statistics()
+
+        current_batch = processed
+        round_count += 1
 
 
 async def schedule_loop(domain: str, batch_size: int, interval: int):
     """以固定週期重複執行流程"""
     while True:
-        await run_once(domain, batch_size)
+        await run_pipeline(domain, batch_size)
         logger.info(f"等待 {interval} 秒後進行下一輪...")
         await asyncio.sleep(interval)
 
@@ -95,7 +133,7 @@ def main():
         logger.info(f"啟動長駐模式，間隔 {args.schedule} 秒")
         asyncio.run(schedule_loop(args.domain, args.batch_size, args.schedule))
     else:
-        asyncio.run(run_once(args.domain, args.batch_size))
+        asyncio.run(run_pipeline(args.domain, args.batch_size))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- 使用 asyncio.TaskGroup 與迴圈，持續 discover→crawl→embed 直到 URLScheduler 清空，並依抓取數調整批次
- 將執行資訊寫入 `logs/auto_pipeline.log`
- README 新增「一鍵全自動流程」與範例指令

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3c08faeec8323af426e0d34ba2a49