### PR TITLE
feat: add FastAPI RAG endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ agentic_rag/
 | `make search QUERY="關鍵問題"` | 進行語義搜尋 |
 | `make migrate-supabase` | 將 PostgreSQL 資料遷移至 Supabase |
 
+## 🌐 API 伺服器
+啟動開發伺服器：
+
+```bash
+uvicorn api.server:app --reload
+```
+
+呼叫範例：
+
+```bash
+curl -X POST "http://localhost:8000/rag/query" \
+  -H "Content-Type: application/json" \
+  -d '{"question": "RAG 是什麼？"}'
+```
+
 ## 🔁 一鍵全自動流程
 若想從發現到向量化一次完成，可執行下列指令：
 

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -1,0 +1,33 @@
+"""共用的 FastAPI 依賴"""
+
+import os
+from functools import lru_cache
+from typing import Generator
+
+import google.generativeai as genai
+from config_manager import load_config
+from database.operations import get_database_operations
+
+# 載入 .env 設定
+load_config()
+
+
+def get_db() -> Generator:
+    """提供資料庫連線"""
+    db = get_database_operations()
+    try:
+        yield db
+    finally:
+        if db:
+            db.close()
+
+
+@lru_cache
+def get_a2a_client() -> genai.GenerativeModel:
+    """取得 Google A2A API 客戶端"""
+    api_key = os.getenv("GOOGLE_API_KEY")
+    if not api_key:
+        raise RuntimeError("缺少 GOOGLE_API_KEY")
+    genai.configure(api_key=api_key)
+    model_name = os.getenv("GOOGLE_A2A_MODEL", "gemini-1.5-pro")
+    return genai.GenerativeModel(model_name)

--- a/api/server.py
+++ b/api/server.py
@@ -1,0 +1,52 @@
+"""簡易的 RAG API 伺服器"""
+
+from fastapi import Depends, FastAPI, HTTPException
+from pydantic import BaseModel
+
+from .dependencies import get_db, get_a2a_client
+from embedding.embedding import embed_text
+
+app = FastAPI()
+
+
+class QueryRequest(BaseModel):
+    """使用者查詢資料模型"""
+
+    question: str
+
+
+@app.post("/rag/query")
+async def rag_query(req: QueryRequest, db=Depends(get_db), model=Depends(get_a2a_client)):
+    """處理 RAG 查詢"""
+    # 1. 生成問題的嵌入向量
+    embedding_tensor = embed_text(req.question)
+    if embedding_tensor is None:
+        raise HTTPException(status_code=500, detail="無法生成嵌入向量")
+    embedding = embedding_tensor[0].tolist()
+
+    # 2. 從資料庫搜尋相似內容
+    sql = (
+        """
+        SELECT ac.content AS chunk_content, a.url AS article_url, a.title AS article_title
+        FROM article_chunks ac
+        JOIN articles a ON ac.article_id = a.id
+        ORDER BY ac.embedding <=> %s
+        LIMIT 5
+        """
+    )
+    rows = db.client.execute_query(sql, (embedding,))
+    if not rows:
+        raise HTTPException(status_code=404, detail="找不到相關內容")
+
+    context = "\n".join(row["chunk_content"] for row in rows)
+
+    # 3. 呼叫 Google A2A 生成回答
+    prompt = f"請根據以下內容回答問題：{req.question}\n\n{context}"
+    try:
+        result = model.generate_content(prompt)
+        answer = result.text
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Google A2A 呼叫失敗: {e}")
+
+    sources = [row["article_url"] for row in rows]
+    return {"answer": answer, "sources": sources}

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,11 @@ supabase==2.18.1
 # Utilities
 python-dotenv==1.1.1
 
+# API
+fastapi==0.116.1
+uvicorn==0.35.0
+google-generativeai==0.8.5
+
 # Testing
 pytest==8.4.1
 pytest-asyncio==1.1.0


### PR DESCRIPTION
## Summary
- add FastAPI server with `/rag/query` endpoint
- share database and Google A2A client dependencies
- document server usage and install API packages

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3c6d7422c83238cce0f81f690dde1